### PR TITLE
Fix check fail

### DIFF
--- a/src/routes/sitemap.xml/+server.ts
+++ b/src/routes/sitemap.xml/+server.ts
@@ -26,6 +26,6 @@ export const GET: RequestHandler = async () => {
   });
 };
 
-function trimTrailingSlash(path) {
+function trimTrailingSlash(path: string) {
   return path.replace(/\/$/, '');
 }


### PR DESCRIPTION
```
 /home/runner/work/www.nukosuke.com/www.nukosuke.com/src/routes/sitemap.xml/+server.ts:29:28
Error: Parameter 'path' implicitly has an 'any' type. 

function trimTrailingSlash(path) {
  return path.replace(/\/$/, '');
```