### PR TITLE
言語切り替えリンク追加

### DIFF
--- a/src/routes/+layout.ts
+++ b/src/routes/+layout.ts
@@ -1,1 +1,2 @@
 export const prerender = true;
+export const trailingSlash = 'always';

--- a/src/routes/Nav.svelte
+++ b/src/routes/Nav.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import * as m from '$lib/paraglide/messages';
+  import { localizeHref, setLocale } from '$lib/paraglide/runtime';
 
   type HeaderProps = { activeSection: string };
   let { activeSection }: HeaderProps = $props();
@@ -12,16 +13,33 @@
     { targetId: 'sec-job', title: m.section_title_job() },
     { targetId: 'sec-blog', title: m.section_title_blog() },
   ];
+
+  // デフォルトの click イベントだと path は書きかわるが遷移しないので明示的に reload する
+  function switchLocale(locale: 'ja' | 'en') {
+    return (event: Event) => {
+      event.preventDefault();
+      setLocale(locale, { reload: true });
+    };
+  }
 </script>
 
 <nav
   class="sticky top-0 z-10 mt-4 rounded-t-sm bg-[#fff4e0] px-8 py-3 text-sm font-bold md:mt-0 md:rounded-b-sm"
 >
-  <ul class="inline-flex gap-2">
-    {#each sections as sec, index (index)}
-      <li class={activeSection === sec.targetId ? [defaultClasses, activeClasses] : defaultClasses}>
-        <a href="#{sec.targetId}">{sec.title}</a>
-      </li>
-    {/each}
-  </ul>
+  <div class="flex justify-between">
+    <ul class="inline-flex gap-2">
+      {#each sections as sec, index (index)}
+        <li
+          class={activeSection === sec.targetId ? [defaultClasses, activeClasses] : defaultClasses}
+        >
+          <a href="#{sec.targetId}">{sec.title}</a>
+        </li>
+      {/each}
+    </ul>
+    <ul class="inline-flex gap-1 self-center">
+      <li><a href={localizeHref('/', { locale: 'ja' })} onclick={switchLocale('ja')}>JA</a></li>
+      <li>/</li>
+      <li><a href={localizeHref('/', { locale: 'en' })} onclick={switchLocale('en')}>EN</a></li>
+    </ul>
+  </div>
 </nav>

--- a/src/routes/sitemap.xml/+server.ts
+++ b/src/routes/sitemap.xml/+server.ts
@@ -12,8 +12,7 @@ export const GET: RequestHandler = async () => {
       return paths.map(({ path, ...rest }) => {
         const defaultLocPath = localizeHref(path, { locale: 'ja' });
         const alternates = ['en'].map((loc) => {
-          const locPath = localizeHref(path, { locale: loc });
-          return { lang: loc, path: trimTrailingSlash(locPath) };
+          return { lang: loc, path: localizeHref(path, { locale: loc }) };
         });
 
         return {
@@ -25,7 +24,3 @@ export const GET: RequestHandler = async () => {
     },
   });
 };
-
-function trimTrailingSlash(path: string) {
-  return path.replace(/\/$/, '');
-}


### PR DESCRIPTION
- #559 
- パスに trailingSlash を常につけるよう修正
  - `localizeHref` の生成するパスが trailingSlash ありのため
  - あわせて `sitemap.xml` の生成時で tailingSlash を除去する処理を削除
- 言語切り替えリンクを Nav コンポーネントに配置
  - SSG だと明示的にリロードしないと遷移できないっぽいので click イベントのハンドラを追加して `setLocale` するようにした